### PR TITLE
Use custom Point struct to remove System.Drawing

### DIFF
--- a/XtermSharp.Mac/TerminalView.cs
+++ b/XtermSharp.Mac/TerminalView.cs
@@ -410,7 +410,7 @@ namespace XtermSharp.Mac {
 
 		void UpdateCursorPosition ()
 		{
-			caret.Pos = new System.Drawing.Point (terminal.Buffer.X, terminal.Buffer.Y - terminal.Buffer.YDisp + terminal.Buffer.YBase);
+			caret.Pos = new Point (terminal.Buffer.X, terminal.Buffer.Y - terminal.Buffer.YDisp + terminal.Buffer.YBase);
 		}
 
 		void UpdateDisplay ()

--- a/XtermSharp/Point.cs
+++ b/XtermSharp/Point.cs
@@ -1,0 +1,28 @@
+﻿namespace XtermSharp
+{
+    public struct Point
+    {
+        public static readonly Point Empty;
+
+        public Point(int x, int y)
+        {
+            X = x;
+            Y = y;
+        }
+
+        public int X { get; set; }
+        public int Y { get; set; }
+
+        public bool IsEmpty => X == 0 && Y == 0;
+
+        public static bool operator ==(Point left, Point right) => left.X == right.X && left.Y == right.Y;
+
+        public static bool operator !=(Point left, Point right) => !(left == right);
+
+        public override bool Equals(object obj) => obj is Point point && point.X == X && point.Y == Y;
+
+        public override int GetHashCode() => X.GetHashCode() * 327 + Y.GetHashCode();
+
+        public override string ToString() => "{X=" + X.ToString() + ",Y=" + Y.ToString() + "}";
+    }
+}

--- a/XtermSharp/SearchService.cs
+++ b/XtermSharp/SearchService.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Drawing;
 using System.Text;
 
 namespace XtermSharp {

--- a/XtermSharp/SelectionService.cs
+++ b/XtermSharp/SelectionService.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Drawing;
 using System.Text;
 
 namespace XtermSharp {


### PR DESCRIPTION
The System.Drawing reference is problematic in Unified Mac apps.
As we are only using this reference for the Point struct, it seemed
prudent to just reimplement this.